### PR TITLE
Rearrange result/error message layout

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -17,7 +17,7 @@
           <button v-on:click="derail">Derail</button>
         </div>
         <div id="result-container">
-          <a v-if="result" v-bind:href="result">{{  result }}</a>
+          <p><a v-if="result" v-bind:href="result">{{  result }}</a></p>
           <p v-if="error">Sorry! {{ error }}</p>
           <p class="issue-link">If a link doesn't work, please <a href="https://github.com/Train-Set-Software/off-the-rails/issues/new?&template=broken_link.yml&title=%5BBroken+Link%5D%3A+">raise an issue</a>.</p>
         </div>

--- a/web/index.html
+++ b/web/index.html
@@ -11,12 +11,16 @@
     <div class="container">
       <div class="title"><h1>🚂 Off The Rails</h1></div>
       <div id="app">
-        <label class="url-label" for="URL">URL:</label>
-        <input class="url-input" type="text" name="URL" id="URL" v-model="url" placeholder="Enter URL..." />
-        <a v-if="result" v-bind:href="result">{{  result }}</a>
-        <button v-on:click="derail">Derail</button>
-        <p v-if="error">Sorry! {{ error }}</p>
-        <p class="issue-link">If a link doesn't work, please <a href="https://github.com/Train-Set-Software/off-the-rails/issues/new?&template=broken_link.yml&title=%5BBroken+Link%5D%3A+">raise an issue</a>.</p>
+        <div id="input-container">
+          <label class="url-label" for="URL">URL:</label>
+          <input class="url-input" type="text" name="URL" id="URL" v-model="url" placeholder="Enter URL..." />
+          <button v-on:click="derail">Derail</button>
+        </div>
+        <div id="result-container">
+          <a v-if="result" v-bind:href="result">{{  result }}</a>
+          <p v-if="error">Sorry! {{ error }}</p>
+          <p class="issue-link">If a link doesn't work, please <a href="https://github.com/Train-Set-Software/off-the-rails/issues/new?&template=broken_link.yml&title=%5BBroken+Link%5D%3A+">raise an issue</a>.</p>
+        </div>
       </div>
     </div>
     <script>

--- a/web/styles.css
+++ b/web/styles.css
@@ -32,13 +32,11 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-
-    padding: 0px 5%;
-    width: 100%;
 }
 
 #input-container {
     display: flex;
+    flex-wrap: wrap;
 }
 
 #result-container {

--- a/web/styles.css
+++ b/web/styles.css
@@ -1,6 +1,7 @@
 body {
     font-family: Arial, Helvetica, sans-serif;
     font-size: 16px;
+    color: #333333;
 }
 
 .container {
@@ -27,18 +28,33 @@ body {
 }
 
 #app {
-    padding: 0px 5%;
     display: flex;
-    flex-wrap: nowrap;
-    width: 100%;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
+
+    padding: 0px 5%;
+    width: 100%;
+}
+
+#input-container {
+    display: flex;
+}
+
+#result-container {
+    padding-top: 0.25rem;
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
 }
 
 label {
     flex-shrink: 0;
     margin: 10px 5px;
     font-family: inherit;
+    line-height: 32px;
 }
 
 .url-input {
@@ -72,7 +88,7 @@ button:hover {
 }
 
 .issue-link {
-    align-self: flex-end;
+    /* align-self: flex-end; */
     margin-bottom: 10px;
 }
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -86,7 +86,6 @@ button:hover {
 }
 
 .issue-link {
-    /* align-self: flex-end; */
     margin-bottom: 10px;
 }
 


### PR DESCRIPTION
Re-arranges the page layout, moving the result or error message below the input line rather than being inline.

1080p / iPhone SE with result and error:
<img width="1925" alt="Screenshot 2021-10-30 at 16 01 41" src="https://user-images.githubusercontent.com/46957/139538518-376a4912-ec11-445a-8667-3971431674a9.png">

<img width="376" alt="Screenshot 2021-10-30 at 16 33 32" src="https://user-images.githubusercontent.com/46957/139539636-b4cff406-9e2d-4583-944d-1149343b9ab2.png">
